### PR TITLE
Added support to change the connection mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ less used and can keep the defaults
 - `DOCKER_GROUP` the docker group name, should be same as the docker's host group (defaults to `docker`)
 - `DOCKER_SOCKET` the docker socket location (default is `/var/run/docker.sock`)
 - `JAVA_OPTS` pass java options to the `agent.jar` process (default is not set)
-- `JENKINS_AGENT_CONNECTION_MODE` the connection mode to use to connect to the jenkins's master (default `-http`). If jenkins is running behind a reverse proxy it is advisable to use `-webSocket` to avoid connection problems (for more details see https://www.jenkins.io/doc/book/managing/cli/)
+- `JENKINS_AGENT_CONNECTION_MODE` the connection mode to use to connect to the jenkins's controller (defaults to `-http`)
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ less used and can keep the defaults
 - `DOCKER_GROUP` the docker group name, should be same as the docker's host group (defaults to `docker`)
 - `DOCKER_SOCKET` the docker socket location (default is `/var/run/docker.sock`)
 - `JAVA_OPTS` pass java options to the `agent.jar` process (default is not set)
+- `JENKINS_AGENT_CONNECTION_MODE` the connection mode to use to connect to the jenkins's master (default `-http`). If jenkins is running behind a reverse proxy it is advisable to use `-webSocket` to avoid connection problems (for more details see https://www.jenkins.io/doc/book/managing/cli/)
 
 ***
 

--- a/jenkins-agent
+++ b/jenkins-agent
@@ -12,6 +12,7 @@ DOWNLOAD_DIR=/usr/share/jenkins
 : ${JENKINS_AGENT_MODE:=NORMAL}
 : ${JENKINS_AGENT_NAME:=$HOSTNAME}
 : ${JENKINS_AGENT_NUM_EXECUTORS:=1}
+: ${JENKINS_AGENT_CONNECTION_MODE:=-http}
 
 JENKINS_AGENT_REMOTE_FS="$JENKINS_HOME"
 
@@ -25,7 +26,7 @@ download_cli_jar() {
 
 # a wrapper for jenkins_cli utility
 jenkins_cli() {
-    java -jar "$DOWNLOAD_DIR/cli.jar" -auth "$JENKINS_AUTH" "$@"
+    java -jar "$DOWNLOAD_DIR/cli.jar" "$JENKINS_AGENT_CONNECTION_MODE" -auth "$JENKINS_AUTH" "$@"
 }
 
 # not really used, we use 'jnlpCredentials' instead


### PR DESCRIPTION
When connecting to a jenkins's instance behind a reverse proxy, it is advisable to use the -webSocket mode to avoid problems.